### PR TITLE
attempt to fix GitHub Desktop login error

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -447,6 +447,10 @@
       cmd: make configure && ./configure --prefix=/usr && make > /tmp/git_build_output.txt 2>&1 && make install
       chdir: /home/kasm-default-profile/install_files/git-2.38.1
       executable: /bin/bash
+  - name: Install gnome-keyring
+    apt:
+      name: gnome-keyring
+      update_cache: yes
   - name: Install GitHub Desktop v3.1.1
     apt:
       deb: /home/kasm-default-profile/install_files/GitHubDesktop-linux-3.1.1-linux1.deb


### PR DESCRIPTION
Attempts to resolve #3

## Testing PR
1. clone or download `tetra-workspace-image` repo
2. change directory to `tetra-workspace-image` repo
3. change `:main` to `:pr-9` on image name in `docker-compose.yml`
4. pull docker image with `docker-compose pull` (this may take a few minutes)
5. spin up docker image with `docker-compose up`
6. log into kasm image by going to `https://localhost:6901` in a web browser and enter credentials (see ["Using the image locally" in README](https://github.com/tetrabiodistributed/tetra-workspace-image#using-the-image-locally))
7. open GitHub Desktop from Applications > Accessories > GitHub Desktop
8. see if error persists