### PR TITLE
resolve deprecated `save-state` command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,32 +35,35 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Checkout github repo
+        uses: actions/checkout@v2
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}
-          tag-sha: true
-          tag-edge: false
-          tag-latest: true
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
 
       - name: Login to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_AUTH_TOKEN }}
 
       - name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4.0.0
         with:
           tags: ${{ steps.docker_meta.outputs.tags }} 
           file: ./Dockerfile
           
       - name: Push image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4.0.0
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
closes #25 

- update CI to use docker/metadata-action@v4
- build docker tag from branches, (git) tags, & prs
- update CI to use docker/login-action@v2.1.0
- update CI to use docker/build-push-action@v4.0.0