### PR TITLE
Dynamically bind devices when connected

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - type: bind
         source: ./kasm_user
         target: /home/kasm-user
-    devices:
-      - "/dev/ttyACM0"
+    device_cgroup_rules:
+      - "c 188:* rmw"
     security_opt:
       - seccomp=unconfined
 ...


### PR DESCRIPTION
Adds cgroup_rule for accessing tty devices w/o --priviledged mode. See https://stackoverflow.com/questions/24225647/docker-a-way-to-give-access-to-a-host-usb-or-serial-device

closes #45 